### PR TITLE
Upgrade to Edition 2018 + Async/Await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 derive_builder = "0.9.0"
+futures = "0.3.6"
 hyper = "0.13.8"
 language-tags = "0.2.2"
 log = "0.4.11"
@@ -28,9 +29,9 @@ optional = true
 version = "1.0"
 
 [dev-dependencies]
-glob = "0.3.0"
 colored = "2.0.0"
 env_logger = "0.7.1"
+glob = "0.3.0"
 terminal_size = "0.1.13"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,16 @@ homepage = "https://github.com/yoursvivek/imdb"
 repository = "https://github.com/yoursvivek/imdb"
 readme = "README.md"
 keywords = ["imdb", "scraping", "movies"]
-
+edition = "2018"
 
 [dependencies]
-derive_builder = "0.5.0"
-hyper = "0.11.6"
+derive_builder = "0.9.0"
+hyper = "0.13.8"
 language-tags = "0.2.2"
-log = "0.3.8"
-reqwest = "0.8.0"
-scraper = "0.4.0"
-url = "1.6.0"
+log = "0.4.11"
+reqwest = "0.10.8"
+scraper = "0.12.0"
+url = "2.1.1"
 
 [dependencies.serde]
 optional = true
@@ -28,10 +28,10 @@ optional = true
 version = "1.0"
 
 [dev-dependencies]
-glob = "0.2.11"
-colored = "1.6.0"
-env_logger = "0.4.3"
-terminal_size = "0.1.7"
+glob = "0.3.0"
+colored = "2.0.0"
+env_logger = "0.7.1"
+terminal_size = "0.1.13"
 
 [features]
 serde-impls = [

--- a/examples/top250movies.rs
+++ b/examples/top250movies.rs
@@ -10,11 +10,13 @@ use std::io::Read;
 use std::fs::File;
 use std::iter::Iterator;
 
+use futures::executor::block_on;
+
 use terminal_size::{Width, Height, terminal_size};
 use colored::*;
 
-use imdb::unstable::parser;
-use imdb::{Movie, Language};
+use crate::imdb::unstable::parser;
+use crate::imdb::{Movie, Language};
 
 fn print_one_line(movies: &[Movie], max_title_length: usize) {
     for (i, movie) in movies.iter().enumerate() {
@@ -48,7 +50,7 @@ fn print_two_lines(movies: &[Movie], max_title_length: usize) {
 }
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let args: Vec<String> = ::std::env::args().collect();
 
@@ -64,7 +66,7 @@ fn main() {
         _ => {
             let mut imdb = imdb::IMDb::new();
             imdb.accept_language(Language::da_DK);
-            imdb.top250_movies().unwrap()
+            block_on(imdb.top250_movies()).unwrap()
         }
     };
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,4 +1,3 @@
-use hyper::header::{AcceptLanguage, qitem};
 use std::fmt;
 
 /// Options for IMDb language support via _Accept-Language_
@@ -63,7 +62,7 @@ pub enum Language {
 
 impl Language {
     /// Returns Accept-Language Header of Language Option
-    pub fn accept_language_header(&self) -> AcceptLanguage {
+    pub fn accept_language_header(&self) -> String {
         let language_tag = match *self {
             Language::en_US => langtag!(en;;;US),
             Language::en_GB => langtag!(en;;;GB),
@@ -72,7 +71,7 @@ impl Language {
             Language::da_DK => langtag!(da;;;DK),
             Language::it_IT => langtag!(it;;;IT),
         };
-        AcceptLanguage(vec![qitem(language_tag)])
+        language_tag.to_string()
     }
 
     /// Returns Description of Language Option

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub mod models;
 pub use error::Error;
 pub use language::Language;
 pub use models::Movie;
-pub use self::imdb::IMDb;
+pub use crate::imdb::IMDb;
 
 pub mod unstable {
     //! Unstable Internal APIs.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,12 @@ extern crate log;
 
 #[macro_use]
 extern crate derive_builder;
-extern crate hyper;
+// extern crate hyper;
 #[macro_use]
 extern crate language_tags;
-extern crate reqwest;
-extern crate scraper;
-extern crate url;
+// extern crate reqwest;
+// extern crate scraper;
+// extern crate url;
 
 #[cfg(feature = "serde-impls")]
 #[macro_use]
@@ -63,6 +63,6 @@ pub mod unstable {
     pub mod parser {
         //! Parsers for extracting information from IMDb html pages.
 
-        pub use parser::top250;
+        pub use crate::parser::top250;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,8 @@ pub mod models;
 
 pub use error::Error;
 pub use language::Language;
-pub use imdb::IMDb;
 pub use models::Movie;
+pub use self::imdb::IMDb;
 
 pub mod unstable {
     //! Unstable Internal APIs.

--- a/src/parser/top250.rs
+++ b/src/parser/top250.rs
@@ -2,8 +2,7 @@
 
 use scraper::{Html, Selector, ElementRef};
 
-use models::{Movie, MovieBuilder};
-use models::TitleID;
+use crate::models::{Movie, MovieBuilder, TitleID};
 
 /// function to parse row fragment of top 250 movie html
 fn parse_row_fragment(fragment: &ElementRef) -> Movie {


### PR DESCRIPTION
Implemented minimal changes on Hyper API and upgraded for the 2018 edition.
There was a recurring Ubuntu error when building as hyper was using some old version of `openssl` (not compatible with OpenSSL 1.1.1).

I fixed the tests for calling the async function and am using my version on my chatbot without issues.